### PR TITLE
3 load parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .venv
 .idea
+invocations/

--- a/config/paired-dna.yml
+++ b/config/paired-dna.yml
@@ -1,0 +1,5 @@
+workflow: b94314cb9cb46380
+inputs:
+  - name: FASTQ Dataset
+    id: e49d4a2f705b9571
+history: Paired DNA Test

--- a/config/rna-seq.yml
+++ b/config/rna-seq.yml
@@ -1,4 +1,4 @@
-workflow: a0c65b6b8c63f1d2
+workflow: 3606d3101a772650
 inputs:
   - name: Reference FASTA
     id: '3947ba9ca107312f'
@@ -6,5 +6,5 @@ inputs:
     id: '048a970701a6dc44'
   - name: FASTA Dataset
     id: 'ca5081d2c8f1088a'
-output: RNA seq test results
+history: RNA seq test results
 

--- a/workflow.py
+++ b/workflow.py
@@ -68,8 +68,7 @@ def run():
 	parser = argparse.ArgumentParser(description='Run Galaxy workflows')
 	parser.add_argument('-s', '--server', required=False, help='the Galaxy server URL.')
 	parser.add_argument('-a', '--api-key', required=False, help='your Galaxy API key')
-	parser.add_argument('-w', '--workflow', required=True, help='the name of the workflow to run')
-	parser.add_argument('-H', '--history', required=True, help='the history (dataset) to be run through the workflow')
+	parser.add_argument('-p', '--profile', help='the profile to use to run the workflow')
 
 	args = parser.parse_args()
 	if args.server is not None:
@@ -195,7 +194,6 @@ def histories(argv):
 
 
 if __name__ == '__main__':
-
 	# Get defaults from the environment if available
 	value = os.environ.get('GALAXY_SERVER')
 	if value is not None:


### PR DESCRIPTION
Load runtime parameters (workflow, data inputs, output history) from a YAML file.  The JSON result returned by the `gi.workflows.invoke_workflow()` command is save to the `invocations` directory.

Closes #1 
Closes #2 
