### PR TITLE
Fix: did not handle dataset download command

### DIFF
--- a/uploader.py
+++ b/uploader.py
@@ -238,6 +238,7 @@ library_commands = {
 
 dataset_commands = {
     'upload': dataset_upload,
+    'download': dataset_download,
     'list': dataset_list,
     'delete': dataset_delete,
     'show': dataset_show,


### PR DESCRIPTION
The command dictionary for the `dataset` command did not include an entry for `download`.