### PR TITLE
Implement uploader.py dataset upload

### DIFF
--- a/uploader.py
+++ b/uploader.py
@@ -178,7 +178,7 @@ def workflow_show(args:list):
 #
 def dataset_list(args: list):
     gi = connect()
-    datasets = gi.datasets.get_datasets(deleted=False, purged=False)
+    datasets = gi.datasets.get_datasets(limit=100, deleted=False, purged=False)
     if len(datasets) == 0:
         print('No datasets found')
         return
@@ -190,14 +190,27 @@ def dataset_delete(args: list):
     print("dataset delete not implemented")
 
 def dataset_upload(args: list):
-    print("dataset upload not implemented")
+    gi = connect()
+    if len(args) == 0:
+        print('ERROR: no dataset file given')
+        return
+    elif len(args) == 1:
+        # No history assigned - create new history
+        history = gi.histories.create_history('New BioBlend dataset').get('id')
+    else:
+        history = args[1]
+    path = args[0]
+    pprint(gi.tools.put_url(path, history))
 
 def dataset_download(args: list):
+    gi = connect()
     if len(args) == 0:
         print('ERROR: no workflow ID given')
         return
-    gi = connect()
-    pprint(gi.datasets.download_dataset(args[0]))
+    elif len(args) > 1:
+        pprint(gi.datasets.download_dataset(args[0], file_path=args[1]))
+    else:
+        pprint(gi.datasets.download_dataset(args[0]))
 
 def dataset_show(args: list):  
     print("dataset show not implemented")

--- a/uploader.py
+++ b/uploader.py
@@ -194,13 +194,20 @@ def dataset_upload(args: list):
     if len(args) == 0:
         print('ERROR: no dataset file given')
         return
-    elif len(args) == 1:
-        # No history assigned - create new history
-        history = gi.histories.create_history('New BioBlend dataset').get('id')
     else:
-        history = args[1]
-    path = args[0]
-    pprint(gi.tools.put_url(path, history))
+        index = 1
+        while index < len(args):
+            arg = args[index]
+            index += 1
+            if arg == '-id':
+                history = args[index]
+                index += 1
+            elif arg == '-c':
+                history = gi.histories.create_history(args[index]).get('id')
+                index += 1
+            else:
+                print('ERROR: invalid option')
+    pprint(gi.tools.put_url(args[0], history))
 
 def dataset_download(args: list):
     gi = connect()


### PR DESCRIPTION
Implemented and tested uploader.py dataset upload function. First argument is the URL of the file to be uploaded to Galaxy, the second argument is the destination history ID (if left blank, creates new history and uploads dataset there.)

Added limit of 100 to dataset list function. In a future update, could add an option for an offset. Also added argument to designate the file path for dataset download function (second argument, after dataset ID.)